### PR TITLE
Network/Transport level batching

### DIFF
--- a/bin/config.json
+++ b/bin/config.json
@@ -26,6 +26,8 @@
     "thrifty": false,
     "chan_buffer_size": 1024,
     "buffer_size": 1024,
+    "batching": true,
+    "batch_size_ms": 3,
     "multiversion": false,
     "benchmark": {
         "T": 60,

--- a/config.go
+++ b/config.go
@@ -24,6 +24,9 @@ type Config struct {
 	MultiVersion   bool    `json:"multiversion"`     // create multi-version database
 	Benchmark      Bconfig `json:"benchmark"`        // benchmark configuration
 
+	Batching       bool	   `json:"batching"` 		// whether to use low-level batching at transport layer
+	BatchSizeMs    int     `json:"batch_size_ms"` 	// size of a batch in ms
+
 	// for future implementation
 	// Batching bool `json:"batching"`
 	// Consistency string `json:"consistency"`
@@ -60,6 +63,8 @@ func MakeDefaultConfig() Config {
 		BufferSize:     1024,
 		ChanBufferSize: 1024,
 		MultiVersion:   false,
+		Batching:       true,
+		BatchSizeMs:    3,
 		Benchmark:      DefaultBConfig(),
 	}
 }

--- a/message.go
+++ b/message.go
@@ -3,11 +3,13 @@ package paxi
 import (
 	"encoding/gob"
 	"fmt"
+	"github.com/ailidani/paxi/log"
 )
 
 func init() {
 	gob.Register(Request{})
 	gob.Register(Reply{})
+	gob.Register(PaxiBatchMsg{})
 	gob.Register(Read{})
 	gob.Register(ReadReply{})
 	gob.Register(Transaction{})
@@ -49,6 +51,20 @@ type Reply struct {
 
 func (r Reply) String() string {
 	return fmt.Sprintf("Reply {cmd=%v value=%v}", r.Command, r.Value)
+}
+
+type PaxiBatchMsg struct {
+	Messages  []interface{}
+	Timestamp int64
+}
+
+func (m PaxiBatchMsg) String() string {
+	return fmt.Sprintf("PaxiBatchMsg {|msg|=%d time=%v}", len(m.Messages), m.Timestamp)
+}
+
+func (m* PaxiBatchMsg) AddToBatch(msg interface{}) {
+	m.Messages = append(m.Messages, msg)
+	log.Debugf("Added to Batch %v", m)
 }
 
 // Read can be used as a special request that directly read the value of key without go through replication protocol in Replica

--- a/paxos/replica.go
+++ b/paxos/replica.go
@@ -63,3 +63,4 @@ func (r *Replica) handleRequest(m paxi.Request) {
 		r.Paxos.HandleRequest(m)
 	}
 }
+


### PR DESCRIPTION
Adds batching of Paxi messages on the network/transport layer. The protocols remain unbatched and still process one operation at a time.